### PR TITLE
Add monitor window functionality for user observation during QA

### DIFF
--- a/lx_toolbox/main.py
+++ b/lx_toolbox/main.py
@@ -394,6 +394,9 @@ def qa(ctx, course_id, chapter_section, env, browser, headless, tune):
         # Open workstation console
         lab_mgr.open_workstation_console(course_id=course_id, tune_workstation=tune)
         
+        # Open a monitor window for the user to observe and intervene during QA
+        lab_mgr.open_monitor_window(course_id=course_id, environment=environment, chapter_section=chapter_section)
+        
         # Run QA on exercises
         lab_mgr.run_full_course_qa(
             course_id=course_id, 


### PR DESCRIPTION
- Introduced `open_monitor_window` method in LabManager to allow users to observe QA progress in real time.
- Updated `qa` function to open the monitor window alongside the workstation console.
- Implemented synchronization of the monitor window to the current exercise for better user experience.